### PR TITLE
Add docker compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ The user "1000:1000" should be fine unless your logfiles can't be read by that u
 
 Now you can check the output at http://<node_ip>:9144/metrics
 
+## Docker Compose
+```
+  storj-log-exporter:
+    build: ./storj-log-exporter
+    container_name: storj-log-exporter
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+    ports: ['9144:9144']
+    volumes:
+      - type: 'bind'
+        source: '<path_to_your_logfiles>'
+        target: '/app/logs'
+    command: ["-config", "/app/config.yml"]
+ ```
+
 ## Configure in prometheus.yml
 
 If you followed my [How-To monitor all nodes in your lan](https://forum.storj.io/t/how-to-monitor-all-nodes-in-your-lan-using-prometheus-grafana-linux-using-docker) on the storj forum, you should already have a job in prometheus.yml looking like this:

--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ Now you can check the output at http://<node_ip>:9144/metrics
 ## Docker Compose
 ```
   storj-log-exporter:
-    build: ./storj-log-exporter
+    image: kevinkk525/storj-log-exporter:latest
     container_name: storj-log-exporter
     restart: unless-stopped
-    environment:
-      - PUID=1000
-      - PGID=1000
-    ports: ['9144:9144']
+    user: "1000:1000"
+    networks:
+      - default
+#    ports: 
+#      - 9144:9144
     volumes:
-      - type: 'bind'
-        source: '<path_to_your_logfiles>'
-        target: '/app/logs'
-    command: ["-config", "/app/config.yml"]
+      - type: bind
+        source: <path_to_your_logfiles>
+        target: /app/logs
+    command: -config /app/config.yml
  ```
 
 ## Configure in prometheus.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The user "1000:1000" should be fine unless your logfiles can't be read by that u
 Now you can check the output at http://<node_ip>:9144/metrics
 
 ## Docker Compose
+Alternatively, you can add the following docker-compose example to your existing docker-compose config for your storagenode:
 ```
   storj-log-exporter:
     image: kevinkk525/storj-log-exporter:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,14 @@
----
-version: '2.3'
-
   storj-log-exporter:
-    build: ./storj-log-exporter
+    image: kevinkk525/storj-log-exporter:latest
     container_name: storj-log-exporter
     restart: unless-stopped
-    environment:
-      - PUID=1000
-      - PGID=1000
-    ports: ['9144:9144']
+    user: "1000:1000"
+    networks:
+      - default
+#    ports: 
+#      - 9144:9144
     volumes:
-      - type: 'bind'
-        source: '<path_to_your_logfiles>'
-        target: '/app/logs'
-    command: ["-config", "/app/config.yml"]
+      - type: bind
+        source: <path_to_your_logfiles>
+        target: /app/logs
+    command: -config /app/config.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: '2.3'
+
+  storj-log-exporter:
+    build: ./storj-log-exporter
+    container_name: storj-log-exporter
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+    ports: ['9144:9144']
+    volumes:
+      - type: 'bind'
+        source: '<path_to_your_logfiles>'
+        target: '/app/logs'
+    command: ["-config", "/app/config.yml"]


### PR DESCRIPTION
Added a new file called docker-compose.yml and edited the README.md file to provide a docker compose example in addition to the docker run example you already had. I'm using the docker compose solution to deploy your project currently, works great.